### PR TITLE
Add slack alerts

### DIFF
--- a/cmd/tenable-scan-launcher/root.go
+++ b/cmd/tenable-scan-launcher/root.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/Invoca/tenable-scan-launcher/pkg/config"
 	"github.com/Invoca/tenable-scan-launcher/pkg/runner"
 	log "github.com/sirupsen/logrus"
@@ -49,6 +50,8 @@ import (
     --summary-report(vuln_hosts_summary)
 	--report-file-location
 
+	--slack-url
+
 */
 
 type logConfig struct {
@@ -60,9 +63,11 @@ func NewRootCmd() *cobra.Command {
 	baseConfig := config.BaseConfig{}
 	tenableConfig := config.TenableConfig{}
 	gcloudConfig := config.GCloudConfig{}
+	slackConfig := config.SlackConfig{}
 
 	baseConfig.TenableConfig = &tenableConfig
 	baseConfig.GCloudConfig = &gcloudConfig
+	baseConfig.SlackConfig = &slackConfig
 
 	logConfig := logConfig{}
 
@@ -116,6 +121,8 @@ instances given based on the scanner id. It is also able to export the scans and
 	f.BoolVarP(&baseConfig.TenableConfig.SummaryReport, "summary-report", "S", false, "Generate A report in summary format")
 	f.BoolVarP(&baseConfig.TenableConfig.FullReport, "full-report", "F", false, "Generate A report with all chapters")
 	f.StringVarP(&baseConfig.TenableConfig.FilePath, "report-file-location", "", "", "File Location of the report")
+
+	f.StringVarP(&baseConfig.SlackConfig.SlackURL, "slack-url", "u", "", "Slack URL to post messages to")
 
 	return cmd
 }

--- a/cmd/tenable-scan-launcher/root_test.go
+++ b/cmd/tenable-scan-launcher/root_test.go
@@ -1,11 +1,12 @@
 package main
 
 import (
+	"strconv"
+	"testing"
+
 	"github.com/Invoca/tenable-scan-launcher/pkg/config"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	"strconv"
-	"testing"
 )
 
 type setupRunnerTestCast struct {
@@ -37,6 +38,7 @@ func TestSetupBaseConfig(t *testing.T) {
 		"filter-search-type",
 		"report-format",
 		"report-file-location",
+		"u",
 	}
 
 	newCmd := NewRootCmd()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,7 +20,11 @@ type TenableConfig struct {
 type GCloudConfig struct {
 	ServiceAccountPath string
 	ProjectName        string
-	Concurrency		   int
+	Concurrency        int
+}
+
+type SlackConfig struct {
+	SlackURL string
 }
 
 type BaseConfig struct {
@@ -29,4 +33,5 @@ type BaseConfig struct {
 	HighSeverity  bool
 	TenableConfig *TenableConfig
 	GCloudConfig  *GCloudConfig
+	SlackConfig   *SlackConfig
 }

--- a/pkg/mocks/slack.go
+++ b/pkg/mocks/slack.go
@@ -13,8 +13,8 @@ type SlackInterfaceMock struct {
 func (s *SlackInterfaceMock) PrintAlerts(alerts tenable.Alerts) error {
 	fmt.Println("Slack Mock")
 	args := s.Called()
-	x := args.Error(0)
-	fmt.Println(x)
-	return x
+	err := args.Error(0)
+	fmt.Println(err)
+	return err
 
 }

--- a/pkg/mocks/slack.go
+++ b/pkg/mocks/slack.go
@@ -1,0 +1,16 @@
+package mocks
+
+import "github.com/Invoca/tenable-scan-launcher/pkg/tenable"
+
+type SlackInterfaceMock struct {
+	ResettableMock
+}
+
+func (s *SlackInterfaceMock) PrintAlerts(alerts tenable.Alerts) error {
+	args := s.Called(nil)
+	if args.Get(0) == nil {
+		return args.Error(0)
+	} else {
+		return args.Error(0)
+	}
+}

--- a/pkg/mocks/slack.go
+++ b/pkg/mocks/slack.go
@@ -1,16 +1,20 @@
 package mocks
 
-import "github.com/Invoca/tenable-scan-launcher/pkg/tenable"
+import (
+	"fmt"
+
+	"github.com/Invoca/tenable-scan-launcher/pkg/tenable"
+)
 
 type SlackInterfaceMock struct {
 	ResettableMock
 }
 
 func (s *SlackInterfaceMock) PrintAlerts(alerts tenable.Alerts) error {
-	args := s.Called(nil)
-	if args.Get(0) == nil {
-		return args.Error(0)
-	} else {
-		return args.Error(0)
-	}
+	fmt.Println("Slack Mock")
+	args := s.Called()
+	x := args.Error(0)
+	fmt.Println(x)
+	return x
+
 }

--- a/pkg/mocks/tenable.go
+++ b/pkg/mocks/tenable.go
@@ -2,6 +2,9 @@ package mocks
 
 import (
 	"fmt"
+
+	"github.com/Invoca/tenable-scan-launcher/pkg/tenable"
+	t "github.com/Invoca/tenable-scan-launcher/pkg/tenable"
 )
 
 type MockTenableAPI struct {
@@ -42,4 +45,11 @@ func (m *MockTenableAPI) WaitForScanToComplete() error {
 	fmt.Println("WaitForScanToComplete Mock")
 	args := m.Called()
 	return args.Error(0)
+}
+
+func (m *MockTenableAPI) GetVulnerabilities() (*t.Alerts, error) {
+	fmt.Println("Get Vulnerabilities Mock")
+	args := m.Called()
+	return args.Get(0).(*tenable.Alerts), args.Error(1)
+
 }

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -98,7 +98,7 @@ func (r *Runner) Run() error {
 	if err != nil {
 		return fmt.Errorf("Run: Error Fetching alerts from Tenable Dashboard %s", err)
 	}
-	if alerts.TotalVulnerabilityCount > 1 {
+	if alerts.TotalVulnerabilityCount > 0 {
 		log.Debug("Posting to Slack")
 		err = r.slackSvc.PrintAlerts(*alerts)
 		if err != nil {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -2,17 +2,21 @@ package runner
 
 import (
 	"fmt"
+
 	"github.com/Invoca/tenable-scan-launcher/pkg/aws"
 	"github.com/Invoca/tenable-scan-launcher/pkg/config"
 	"github.com/Invoca/tenable-scan-launcher/pkg/gcloud"
+	"github.com/Invoca/tenable-scan-launcher/pkg/slack"
 	"github.com/Invoca/tenable-scan-launcher/pkg/tenable"
 	"github.com/Invoca/tenable-scan-launcher/pkg/wrapper"
+
 	log "github.com/sirupsen/logrus"
 )
 
 type Runner struct {
 	ec2Svc         wrapper.CloudWrapper
 	gcloud         wrapper.CloudWrapper
+	slackSvc       wrapper.SlackSvc
 	tenable        wrapper.Tenable
 	includeGCloud  bool
 	includeAWS     bool
@@ -21,12 +25,18 @@ type Runner struct {
 
 func (r *Runner) SetupRunner(config *config.BaseConfig) error {
 
+	var err error
 	r.includeAWS = config.IncludeAWS
 	r.includeGCloud = config.IncludeGCloud
 
 	if config.TenableConfig == nil {
 		return fmt.Errorf("SetupRunner: TenableConfig in config cannot be nil")
 	}
+
+	if config.SlackConfig == nil {
+		return fmt.Errorf("SetupRunner: SlackConfig in config cannot be nil ")
+	}
+	r.slackSvc, err = slack.New(*config)
 
 	if r.includeAWS {
 		ec2Svc := &aws.AWSEc2{}
@@ -60,6 +70,7 @@ func (r *Runner) SetupRunner(config *config.BaseConfig) error {
 
 func (r *Runner) Run() error {
 	log.Debug("Run")
+
 	err := r.getIPs()
 	if err != nil {
 		return fmt.Errorf("Run: Error getting ips %s", err)
@@ -80,6 +91,20 @@ func (r *Runner) Run() error {
 	}
 
 	log.Debug("Scan complete.")
+
+	log.Debug("Fetching Critical alerts from Tenable Dashboard")
+	alerts, err := r.tenable.GetVulnerabilities()
+
+	if err != nil {
+		return fmt.Errorf("Run: Error Fetching alerts from Tenable Dashboard %s", err)
+	}
+	if alerts.TotalVulnerabilityCount > 1 {
+		log.Debug("Posting to Slack")
+		err = r.slackSvc.PrintAlerts(*alerts)
+		if err != nil {
+			return fmt.Errorf("Run: Error posting to slack %s", err)
+		}
+	}
 
 	if r.generateReport {
 		err = r.tenable.StartExport()
@@ -145,4 +170,5 @@ func (r *Runner) getIPs() error {
 
 	log.Debug("\n\nALL:", ips)
 	return nil
+
 }

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -170,5 +170,4 @@ func (r *Runner) getIPs() error {
 
 	log.Debug("\n\nALL:", ips)
 	return nil
-
 }

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -172,8 +172,6 @@ func TestRun(t *testing.T) {
 		{
 			desc: "Tenable is not able to get list of vulnerabilites from Tenable dashboard",
 			setup: func() {
-
-				//TODO: Create Test cases with Max
 				ec2Mock.Reset()
 				gcloudMock.Reset()
 				tenableMock.Reset()

--- a/pkg/slack/slack.go
+++ b/pkg/slack/slack.go
@@ -1,0 +1,164 @@
+package slack
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Invoca/tenable-scan-launcher/pkg/config"
+	"github.com/Invoca/tenable-scan-launcher/pkg/tenable"
+
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/time/rate"
+)
+
+type SlackInterface interface {
+	PrintAlerts(tenable.Alerts) error
+}
+
+type markdownText struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type block struct {
+	BlockType string        `json:"type"`
+	BlockText *markdownText `json:"text,omitempty"`
+}
+
+type slackBody struct {
+	Blocks []block `json:"blocks"`
+}
+
+type slack struct {
+	slackUrl  string
+	rateLimit *rateLimitedHTTPClient
+}
+
+type rateLimitedHTTPClient struct {
+	client   *http.Client
+	rlClient *rate.Limiter
+}
+
+func (c *rateLimitedHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	ctx := context.Background()
+	err := c.rlClient.Wait(ctx)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func New(config config.BaseConfig) (*slack, error) {
+	if config.SlackConfig == nil {
+		return nil, fmt.Errorf("Error: SlackConfig cannot be nil")
+	}
+
+	if config.SlackConfig.SlackURL == "" {
+		return nil, fmt.Errorf("Error: SlackURL cannot be empty")
+	}
+
+	s := slack{}
+	s.slackUrl = config.SlackConfig.SlackURL
+	s.rateLimit = &rateLimitedHTTPClient{
+		client:   http.DefaultClient,
+		rlClient: rate.NewLimiter(rate.Every(10*time.Second), 10),
+	}
+
+	return &s, nil
+}
+
+func (s *slack) createBlockSlackPost(text string, additionalText string) error {
+	var blockSlice []block
+
+	divider := block{
+		BlockType: "divider",
+	}
+
+	mainMarkdown := markdownText{
+		Type: "mrkdwn",
+		Text: text,
+	}
+
+	additionalInfoMarkdown := markdownText{
+		Type: "mrkdwn",
+		Text: additionalText,
+	}
+
+	mainBlock := block{
+		BlockType: "section",
+		BlockText: &mainMarkdown,
+	}
+
+	additionalInfoBlock := block{
+		BlockType: "section",
+		BlockText: &additionalInfoMarkdown,
+	}
+
+	blockSlice = append(blockSlice, divider, mainBlock, additionalInfoBlock)
+
+	body := slackBody{Blocks: blockSlice}
+
+	data, _ := json.Marshal(body)
+
+	log.Debug(string(data))
+
+	req, _ := http.NewRequest("POST", s.slackUrl, bytes.NewBuffer(data))
+	resp, err := s.rateLimit.Do(req)
+
+	if err != nil {
+		return fmt.Errorf("createBlockSlackPost: Error Posting Request %s", err)
+	}
+
+	if resp.Status != "200 OK" {
+		return fmt.Errorf("createBlockSlackPost: Received non 200 Status Code %s", err)
+	}
+	log.Debug("Received Status: " + resp.Status)
+	return nil
+}
+
+func (s *slack) formatLabels(labels map[string]string) string {
+	baseString := "Labels:\t"
+	formatSpacing := "\n\t\t\t\t"
+	firstLabel := true
+	for name, value := range labels {
+		if firstLabel {
+			baseString = baseString + name + ": " + value
+			firstLabel = false
+			continue
+		}
+		baseString = baseString + formatSpacing + name + ": " + value
+	}
+	return baseString
+}
+
+func (s *slack) PrintAlerts(alerts tenable.Alerts) error {
+	if s.slackUrl == "" {
+		return fmt.Errorf("PrintOpenedPorts: slackUrl cannot be empty")
+	}
+
+	for _, v := range alerts.Vulnerabilities {
+		v.PluginName = strings.ReplaceAll(v.PluginName, "<", " ")
+		v.PluginName = strings.ReplaceAll(v.PluginName, ">", " ")
+		title := ":red_circle: " + "*" + strconv.FormatUint(uint64(v.Count), 10) + "*" + " instance(s) currently contain(s) the `" + v.VulnerabilityState + "` vulnerability: \n"
+		attachmentText := "<https://www.tenable.com/plugins/nessus/" + strconv.FormatUint(uint64(v.PluginID), 10) + "|" + v.PluginName + ">\n"
+		//		attachmentText = attachmentText + "*Plugin Family:* " + v.PluginFamily + "\n"
+		//		attachmentText = attachmentText + "*Vulnerability Priority Rating:* " + strconv.FormatUint(uint64(v.VprScore), 10) + "\n"
+		//attachmentText = attachmentText + "*Link to Vulnerability:* https://www.tenable.com/plugins/nessus/" + strconv.FormatUint(uint64(v.PluginID), 10)
+
+		err := s.createBlockSlackPost(title, attachmentText)
+		if err != nil {
+			return fmt.Errorf("PrintAlerts: Error posting message to slack %s", err)
+		}
+	}
+	return nil
+}

--- a/pkg/slack/slack.go
+++ b/pkg/slack/slack.go
@@ -151,10 +151,6 @@ func (s *slack) PrintAlerts(alerts tenable.Alerts) error {
 		v.PluginName = strings.ReplaceAll(v.PluginName, ">", " ")
 		title := ":red_circle: " + "*" + strconv.FormatUint(uint64(v.Count), 10) + "*" + " instance(s) currently contain(s) the `" + v.VulnerabilityState + "` vulnerability: \n"
 		attachmentText := "<https://www.tenable.com/plugins/nessus/" + strconv.FormatUint(uint64(v.PluginID), 10) + "|" + v.PluginName + ">\n"
-		//		attachmentText = attachmentText + "*Plugin Family:* " + v.PluginFamily + "\n"
-		//		attachmentText = attachmentText + "*Vulnerability Priority Rating:* " + strconv.FormatUint(uint64(v.VprScore), 10) + "\n"
-		//attachmentText = attachmentText + "*Link to Vulnerability:* https://www.tenable.com/plugins/nessus/" + strconv.FormatUint(uint64(v.PluginID), 10)
-
 		err := s.createBlockSlackPost(title, attachmentText)
 		if err != nil {
 			return fmt.Errorf("PrintAlerts: Error posting message to slack %s", err)

--- a/pkg/slack/slack_test.go
+++ b/pkg/slack/slack_test.go
@@ -1,0 +1,69 @@
+package slack
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/Invoca/tenable-scan-launcher/pkg/tenable"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/time/rate"
+)
+
+type slackTestCase struct {
+	desc        string
+	setup       func() *httptest.Server
+	shouldError bool
+}
+
+func PrintAlerts(t *testing.T) {
+	log.SetLevel(log.DebugLevel)
+
+	slackInterface := slack{}
+	slackInterface.rateLimit = &rateLimitedHTTPClient{
+		client:   http.DefaultClient,
+		rlClient: rate.NewLimiter(rate.Every(10*time.Second), 10),
+	}
+
+	testCases := []slackTestCase{
+		{
+			desc: "Able to post to slack",
+			setup: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+			},
+			shouldError: false,
+		},
+		{
+			desc: "Error posting to slack",
+			setup: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(500)
+				}))
+			},
+			shouldError: true,
+		},
+	}
+
+	for index, testCase := range testCases {
+		log.WithFields(log.Fields{
+			"desc":        testCase.desc,
+			"shouldError": testCase.shouldError,
+		}).Debug("Starting testCase " + strconv.Itoa(index))
+
+		testServer := testCase.setup()
+		slackInterface.slackUrl = testServer.URL
+
+		err := slackInterface.PrintAlerts(tenable.Alerts{})
+
+		testServer.Close()
+
+		if testCase.shouldError {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+		}
+	}
+}

--- a/pkg/wrapper/slack.go
+++ b/pkg/wrapper/slack.go
@@ -1,0 +1,9 @@
+package wrapper
+
+import (
+	t "github.com/Invoca/tenable-scan-launcher/pkg/tenable"
+)
+
+type SlackSvc interface {
+	PrintAlerts(t.Alerts) error
+}

--- a/pkg/wrapper/tenable.go
+++ b/pkg/wrapper/tenable.go
@@ -1,5 +1,9 @@
 package wrapper
 
+import (
+	t "github.com/Invoca/tenable-scan-launcher/pkg/tenable"
+)
+
 type Tenable interface {
 	SetTargets([]string) error
 	LaunchScan() error
@@ -7,4 +11,5 @@ type Tenable interface {
 	StartExport() error
 	WaitForExport() error
 	DownloadExport() error
+	GetVulnerabilities() (*t.Alerts, error)
 }


### PR DESCRIPTION
This PR adds the functionality to query the Tenable API for active vulnerabilities and posts notifications to the slack channel tenable_alerts.