### PR TITLE
Removing the status fetching, other elements not needed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,5 +12,7 @@ require (
 	github.com/spf13/viper v1.7.0 // indirect
 	github.com/stretchr/testify v1.5.1
 	golang.org/dl v0.0.0-20200724191219-e4fbcf8a7a81 // indirect
+	golang.org/x/sys v0.0.0-20220513210249-45d2b4557a2a // indirect
+	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 	google.golang.org/api v0.13.0
 )

--- a/go.sum
+++ b/go.sum
@@ -492,6 +492,8 @@ golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa h1:KIDDMLT1O0Nr7TSxp8xM5tJcdn8tgyAONntO829og1M=
 golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220513210249-45d2b4557a2a h1:N2T1jUrTQE9Re6TFF5PhvEHXHCguynGhKjWVsIUt5cY=
+golang.org/x/sys v0.0.0-20220513210249-45d2b4557a2a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/mocks/tenable.go
+++ b/pkg/mocks/tenable.go
@@ -2,8 +2,8 @@ package mocks
 
 import (
 	"fmt"
-
-	"github.com/Invoca/tenable-scan-launcher/pkg/tenable"
+	//"github.com/Invoca/tenable-scan-launcher/pkg/tenable"
+	
 	t "github.com/Invoca/tenable-scan-launcher/pkg/tenable"
 )
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -84,50 +84,50 @@ func (r *Runner) Run() error {
 	}
 
 	log.Debug("Scan launched. Waiting for scan to complete.")
-
-	err = r.tenable.WaitForScanToComplete()
-	if err != nil {
-		return fmt.Errorf("Run: Error Waiting For Scan To Complete %s", err)
-	}
-
-	log.Debug("Scan complete.")
-
-	log.Debug("Fetching Critical alerts from Tenable Dashboard")
-	alerts, err := r.tenable.GetVulnerabilities()
-
-	if err != nil {
-		return fmt.Errorf("Run: Error Fetching alerts from Tenable Dashboard %s", err)
-	}
-	if alerts.TotalVulnerabilityCount > 0 {
-		log.Debug("Posting to Slack")
-		err = r.slackSvc.PrintAlerts(*alerts)
+	/**
+		err = r.tenable.WaitForScanToComplete()
 		if err != nil {
-			return fmt.Errorf("Run: Error posting to slack %s", err)
-		}
-	}
-
-	if r.generateReport {
-		err = r.tenable.StartExport()
-		if err != nil {
-			return fmt.Errorf("Run: Error Starting Scan %s", err)
+			return fmt.Errorf("Run: Error Waiting For Scan To Complete %s", err)
 		}
 
-		log.Debug("Export Started. Waiting for file to be ready.")
+		log.Debug("Scan complete.")
 
-		err = r.tenable.WaitForExport()
+		log.Debug("Fetching Critical alerts from Tenable Dashboard")
+		alerts, err := r.tenable.GetVulnerabilities()
+
 		if err != nil {
-			return fmt.Errorf("Run: Error Waiting For Export %s", err)
+			return fmt.Errorf("Run: Error Fetching alerts from Tenable Dashboard %s", err)
+		}
+		if alerts.TotalVulnerabilityCount > 0 {
+			log.Debug("Posting to Slack")
+			err = r.slackSvc.PrintAlerts(*alerts)
+			if err != nil {
+				return fmt.Errorf("Run: Error posting to slack %s", err)
+			}
 		}
 
-		log.Debug("Starting file download")
+		if r.generateReport {
+			err = r.tenable.StartExport()
+			if err != nil {
+				return fmt.Errorf("Run: Error Starting Scan %s", err)
+			}
 
-		err = r.tenable.DownloadExport()
-		if err != nil {
-			return fmt.Errorf("Run: Error Downloading Export %s", err)
+			log.Debug("Export Started. Waiting for file to be ready.")
+
+			err = r.tenable.WaitForExport()
+			if err != nil {
+				return fmt.Errorf("Run: Error Waiting For Export %s", err)
+			}
+
+			log.Debug("Starting file download")
+
+			err = r.tenable.DownloadExport()
+			if err != nil {
+				return fmt.Errorf("Run: Error Downloading Export %s", err)
+			}
+			log.Debug("File successfully downloaded")
 		}
-		log.Debug("File successfully downloaded")
-	}
-
+	**/
 	log.Debug("Run Finished")
 	return nil
 }

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -72,10 +72,10 @@ func TestRun(t *testing.T) {
 				slackMock.On("PrintAlerts", mock.Anything).Return(nil)
 				tenableMock.On("SetTargets", mock.Anything).Return(nil)
 				tenableMock.On("LaunchScan", mock.Anything).Return(nil)
-				tenableMock.On("WaitForScanToComplete", mock.Anything).Return(nil)
-				tenableMock.On("StartExport", mock.Anything).Return(nil)
-				tenableMock.On("WaitForExport", mock.Anything).Return(nil)
-				tenableMock.On("DownloadExport", mock.Anything).Return(nil)
+				//tenableMock.On("WaitForScanToComplete", mock.Anything).Return(nil)
+				//tenableMock.On("StartExport", mock.Anything).Return(nil)
+				//tenableMock.On("WaitForExport", mock.Anything).Return(nil)
+				//tenableMock.On("DownloadExport", mock.Anything).Return(nil)
 			},
 			shouldError: false,
 		},
@@ -165,7 +165,7 @@ func TestRun(t *testing.T) {
 
 				tenableMock.On("SetTargets", mock.Anything).Return(nil)
 				tenableMock.On("LaunchScan", mock.Anything).Return(nil)
-				tenableMock.On("WaitForScanToComplete", mock.Anything).Return(fmt.Errorf("Tenable Error"))
+				//tenableMock.On("WaitForScanToComplete", mock.Anything).Return(fmt.Errorf("Tenable Error"))
 			},
 			shouldError: true,
 		},
@@ -185,8 +185,8 @@ func TestRun(t *testing.T) {
 
 				tenableMock.On("SetTargets", mock.Anything).Return(nil)
 				tenableMock.On("LaunchScan", mock.Anything).Return(nil)
-				tenableMock.On("WaitForScanToComplete", mock.Anything).Return(nil)
-				tenableMock.On("GetVulnerabilities", mock.Anything).Return(&alerts, fmt.Errorf("Error getting Vulnerabilities from Dashboard"))
+				//tenableMock.On("WaitForScanToComplete", mock.Anything).Return(nil)
+				//tenableMock.On("GetVulnerabilities", mock.Anything).Return(&alerts, fmt.Errorf("Error getting Vulnerabilities from Dashboard"))
 
 			},
 			shouldError: true,
@@ -207,9 +207,9 @@ func TestRun(t *testing.T) {
 
 				tenableMock.On("SetTargets", mock.Anything).Return(nil)
 				tenableMock.On("LaunchScan", mock.Anything).Return(nil)
-				tenableMock.On("WaitForScanToComplete", mock.Anything).Return(nil)
-				tenableMock.On("GetVulnerabilities", mock.Anything).Return(&alerts, nil)
-				slackMock.On("PrintAlerts", mock.Anything).Return(fmt.Errorf("Error"))
+				//tenableMock.On("WaitForScanToComplete", mock.Anything).Return(nil)
+				//tenableMock.On("GetVulnerabilities", mock.Anything).Return(&alerts, nil)
+				//slackMock.On("PrintAlerts", mock.Anything).Return(fmt.Errorf("Error"))
 
 			},
 			shouldError: true,
@@ -230,10 +230,10 @@ func TestRun(t *testing.T) {
 
 				tenableMock.On("SetTargets", mock.Anything).Return(nil)
 				tenableMock.On("LaunchScan", mock.Anything).Return(nil)
-				tenableMock.On("WaitForScanToComplete", mock.Anything).Return(nil)
-				tenableMock.On("GetVulnerabilities", mock.Anything).Return(&alerts, nil)
-				slackMock.On("PrintAlerts", mock.Anything).Return(nil)
-				tenableMock.On("StartExport", mock.Anything).Return(fmt.Errorf("Error!"))
+				//tenableMock.On("WaitForScanToComplete", mock.Anything).Return(nil)
+				//tenableMock.On("GetVulnerabilities", mock.Anything).Return(&alerts, nil)
+				//slackMock.On("PrintAlerts", mock.Anything).Return(nil)
+				//tenableMock.On("StartExport", mock.Anything).Return(fmt.Errorf("Error!"))
 			},
 			shouldError: true,
 		},
@@ -253,11 +253,11 @@ func TestRun(t *testing.T) {
 
 				tenableMock.On("SetTargets", mock.Anything).Return(nil)
 				tenableMock.On("LaunchScan", mock.Anything).Return(nil)
-				tenableMock.On("WaitForScanToComplete", mock.Anything).Return(nil)
-				tenableMock.On("GetVulnerabilities", mock.Anything).Return(&alerts, nil)
-				slackMock.On("PrintAlerts", mock.Anything).Return(nil)
-				tenableMock.On("StartExport", mock.Anything).Return(nil)
-				tenableMock.On("WaitForExport", mock.Anything).Return(fmt.Errorf("Error!"))
+				//tenableMock.On("WaitForScanToComplete", mock.Anything).Return(nil)
+				//tenableMock.On("GetVulnerabilities", mock.Anything).Return(&alerts, nil)
+				//slackMock.On("PrintAlerts", mock.Anything).Return(nil)
+				//tenableMock.On("StartExport", mock.Anything).Return(nil)
+				//tenableMock.On("WaitForExport", mock.Anything).Return(fmt.Errorf("Error!"))
 			},
 			shouldError: true,
 		},
@@ -277,12 +277,12 @@ func TestRun(t *testing.T) {
 
 				tenableMock.On("SetTargets", mock.Anything).Return(nil)
 				tenableMock.On("LaunchScan", mock.Anything).Return(nil)
-				tenableMock.On("WaitForScanToComplete", mock.Anything).Return(nil)
-				tenableMock.On("GetVulnerabilities", mock.Anything).Return(&alerts, nil)
-				slackMock.On("PrintAlerts", mock.Anything).Return(nil)
-				tenableMock.On("StartExport", mock.Anything).Return(nil)
-				tenableMock.On("WaitForExport", mock.Anything).Return(nil)
-				tenableMock.On("DownloadExport", mock.Anything).Return(fmt.Errorf("Error!"))
+				//tenableMock.On("WaitForScanToComplete", mock.Anything).Return(nil)
+				//tenableMock.On("GetVulnerabilities", mock.Anything).Return(&alerts, nil)
+				//slackMock.On("PrintAlerts", mock.Anything).Return(nil)
+				//tenableMock.On("StartExport", mock.Anything).Return(nil)
+				//tenableMock.On("WaitForExport", mock.Anything).Return(nil)
+				//tenableMock.On("DownloadExport", mock.Anything).Return(fmt.Errorf("Error!"))
 			},
 			shouldError: true,
 		},

--- a/pkg/wrapper/tenable.go
+++ b/pkg/wrapper/tenable.go
@@ -7,9 +7,9 @@ import (
 type Tenable interface {
 	SetTargets([]string) error
 	LaunchScan() error
-	WaitForScanToComplete() error
-	StartExport() error
-	WaitForExport() error
-	DownloadExport() error
+	//WaitForScanToComplete() error
+	//StartExport() error
+	//WaitForExport() error
+	//DownloadExport() error
 	GetVulnerabilities() (*t.Alerts, error)
 }


### PR DESCRIPTION
This code was brought to you by @escheiner who commented out sections of the code that was causing a 502 & 409 error, this will just gather the IPs necessary to run the scan properly. The scanner will skip any status checking of the scan, and it will just run successfully. 